### PR TITLE
Add i18n for CLI logs

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -33,7 +33,7 @@ export async function summarizeCommits(grouped, model, isVerbose, lang) {
 async function main() {
   const { isVerbose, lang } = await setupCLI();
 
-  const result = await getAndValidateDiff(isVerbose);
+  const result = await getAndValidateDiff(isVerbose, lang);
 
   if (!result) {
     return;
@@ -44,16 +44,17 @@ async function main() {
 
   if (!blocks) return;
 
-  const model = await chooseModel();
+  const model = await chooseModel(lang);
   const { parsedBlocks } = await analyzeBlocksWithIA(
     blocks,
     model,
     isVerbose,
-    removedBlocks
+    removedBlocks,
+    lang
   );
 
   const grouped = agruparPorRelaciones(parsedBlocks);
-  printGitAdviceIfNeeded(grouped);
+  printGitAdviceIfNeeded(grouped, lang);
 
   const summaries = await summarizeCommits(grouped, model, isVerbose, lang);
 
@@ -61,8 +62,8 @@ async function main() {
   // console.log(chalk.gray("\n📤 summaries:\n"));
   // console.dir(summaries, { depth: null, colors: true });
 
-  const accion = await promptCommitAction(summaries);
-  await performCommitActions(accion, summaries, blocks);
+  const accion = await promptCommitAction(summaries, lang);
+  await performCommitActions(accion, summaries, blocks, lang);
 }
 
 main();

--- a/src/analyzeFlow.js
+++ b/src/analyzeFlow.js
@@ -2,27 +2,28 @@ import ora from "ora";
 import chalk from "chalk";
 import path from "path";
 import { analyzeDiffBlock, analyzeDeletesBlocks } from "./analyzeWithLLM.js";
+import { t } from "./i18n.js";
 
 export async function analyzeBlocksWithIA(
   blocks,
   model,
   isVerbose,
-  removedBlocks = []
+  removedBlocks = [],
+  lang = "en"
 ) {
   const parsedBlocks = [];
 
   if (removedBlocks.length > 0) {
-    const spinner = ora(
-      "🗑️ Analizando archivos eliminados/refactorizados..."
-    ).start();
+    const spinner = ora(t("analyzingDeleted", lang)).start();
     try {
       const result = await analyzeDeletesBlocks(
         removedBlocks,
         model,
 
-        isVerbose
+        isVerbose,
+        lang
       );
-      spinner.succeed("🧾 Deleted/refactored files summarized");
+      spinner.succeed(t("deletedSummarySuccess", lang));
 
       const relatedFiles = Array.from(
         new Set(
@@ -42,22 +43,26 @@ export async function analyzeBlocksWithIA(
       parsedBlocks.push(parsed);
 
       if (isVerbose) {
-        console.log(
-          chalk.blueBright("\n📚 Summary for deleted/refactored files:\n")
-        );
+        console.log(chalk.blueBright(t("verboseDeletedSummary", lang)));
         console.dir(result, { depth: null, colors: true });
       }
     } catch (err) {
-      spinner.fail("❌ Error processing deleted/refactored files");
+      spinner.fail(t("errorProcessingDeleted", lang));
       console.error(err);
     }
   }
 
   for (const { filePath, block } of blocks) {
-    const spinner = ora(`🤖 Analizando ${filePath} con IA...`).start();
+    const spinner = ora(t("analyzingFile", lang).replace("{file}", filePath)).start();
     try {
-      const result = await analyzeDiffBlock(block, model, filePath, isVerbose);
-      spinner.succeed(`📄 ${filePath} procesado correctamente`);
+      const result = await analyzeDiffBlock(
+        block,
+        model,
+        filePath,
+        isVerbose,
+        lang
+      );
+      spinner.succeed(t("fileProcessed", lang).replace("{file}", filePath));
 
       const parsed = {
         title: result.title,
@@ -69,11 +74,11 @@ export async function analyzeBlocksWithIA(
       parsedBlocks.push(parsed);
 
       if (isVerbose) {
-        console.log(chalk.blueBright("\n📚 Respuesta de analyzeDiffBlock:\n"));
+        console.log(chalk.blueBright(t("verboseAnalyzeResponse", lang)));
         console.dir(result, { depth: null, colors: true });
       }
     } catch (err) {
-      spinner.fail(`❌ Error al procesar ${filePath}`);
+      spinner.fail(t("errorProcessingFile", lang).replace("{file}", filePath));
       console.error(err);
     }
   }
@@ -81,38 +86,18 @@ export async function analyzeBlocksWithIA(
   return { parsedBlocks };
 }
 
-export function printGitAdviceIfNeeded(groupedBlocks) {
+export function printGitAdviceIfNeeded(groupedBlocks, lang = "en") {
   if (groupedBlocks.length <= 1) return;
 
-  console.log(chalk.blueBright("\n📚 Consejo Git:"));
+  console.log(chalk.blueBright(`\n${t("gitAdviceTitle", lang)}`));
   console.log(
-    chalk.gray(
-      `Se recomienda realizar un commit por cada cambio con responsabilidad única.\n` +
-        `Esto mejora la trazabilidad, facilita el trabajo en equipo y el uso de herramientas como git bisect.\n`
-    )
+    chalk.gray(t("gitAdviceText", lang).replace("{tool}", chalk.cyan("ai-commit")))
   );
 
-  console.log(chalk.blueBright("\n🤝 Un consejo más de tu compa AI:"));
+  console.log(chalk.blueBright(`\n${t("aiAdviceTitle", lang)}`));
   console.log(
     chalk.gray(
-      `Uno de los objetivos de ${chalk.cyan(
-        "ai-commit"
-      )} es justamente ayudarte a mejorar la calidad de tus commits. 💎📈\n` +
-        `Commits bien pensados no solo cuentan una mejor historia del código, sino que también\n` +
-        `facilitan el debugging, los PRs y la colaboración con el equipo.\n\n` +
-        `Si te parece bien, la próxima vez que termines una funcionalidad o cambio independiente,\n` +
-        `probá correr directamente ${chalk.cyan(
-          "ai-commit"
-        )} apenas termines ese paso. 🧠⚡\n\n` +
-        `Aunque hoy ${chalk.cyan(
-          "ai-commit"
-        )} puede sugerir múltiples commits separados por archivo o propósito general,\n` +
-        `aún no puede detectar con precisión si hay más de una funcionalidad dentro del mismo archivo o bloque de código.\n` +
-        `Eso requeriría un análisis más profundo del contexto funcional, algo que todavía estamos explorando. 🤖🔬\n\n` +
-        `Por eso, cada vez que termines algo autocontenible, usá ${chalk.cyan(
-          "ai-commit"
-        )} y lo resolvemos en segundos. 🚀\n` +
-        `¡Vos programás, yo comiteo! 😉`
+      t("aiAdviceText", lang).replace(/\{tool\}/g, chalk.cyan("ai-commit"))
     )
   );
 }

--- a/src/analyzeWithLLM.js
+++ b/src/analyzeWithLLM.js
@@ -2,6 +2,7 @@ import axios from "axios";
 import inquirer from "inquirer";
 import chalk from "chalk";
 import { getAPIKey } from "./config.js";
+import { t } from "./i18n.js";
 import path from "path";
 import fs from "fs-extra";
 import { generateReducedTree } from "./generateProjectTree.js";
@@ -26,7 +27,7 @@ function buildChoices(models) {
   return result;
 }
 
-export async function chooseModel() {
+export async function chooseModel(lang = "en") {
   const apiKey = await getAPIKey();
 
   if (!apiKey) {
@@ -41,7 +42,7 @@ export async function chooseModel() {
     {
       type: "list",
       name: "model",
-      message: "\n\n\n🧠 ¿Qué modelo LLM querés usar?",
+      message: t("chooseModel", lang),
       choices: buildChoices(models),
       loop: false, // Evita el scroll circular
     },
@@ -54,7 +55,8 @@ export async function analyzeDiffBlock(
   diffBlock,
   model,
   filePath,
-  verbose = false
+  verbose = false,
+  lang = "en"
 ) {
   const apiKey = await getAPIKey();
   const absolutePath = path.join(process.cwd(), filePath);
@@ -157,7 +159,7 @@ ${fullFileContent}
     );
 
     if (verbose) {
-      console.log(chalk.gray("\n📤 Prompt enviada al modelo:\n"));
+      console.log(chalk.gray(t("promptSent", lang)));
       console.dir(messages, { depth: null, colors: true });
     }
 
@@ -166,16 +168,21 @@ ${fullFileContent}
       const parsed = JSON.parse(raw);
       return parsed;
     } catch (err) {
-      console.error(chalk.red("❌ Error parsing block JSON:"), raw);
+      console.error(chalk.red(`${t("errorParsingJSON", lang)}`), raw);
       return null;
     }
   } catch (error) {
-    console.error(chalk.red("❌ Error in analyzeDiffBlock:"), error.message);
+    console.error(chalk.red(`${t("errorAnalyzeDiffBlock", lang)}`), error.message);
     return "⚠️ Error analyzing diff.";
   }
 }
 
-export async function analyzeDeletesBlocks(diffBlocks, model, verbose = false) {
+export async function analyzeDeletesBlocks(
+  diffBlocks,
+  model,
+  verbose = false,
+  lang = "en"
+) {
   const apiKey = await getAPIKey();
 
   const SYSTEM_CONTENT = `
@@ -254,7 +261,7 @@ ${JSON.stringify(diffBlocks, null, 2)}
     );
 
     if (verbose) {
-      console.log(chalk.gray("\n📤 Prompt enviada al modelo:\n"));
+      console.log(chalk.gray(t("promptSent", lang)));
       console.dir(messages, { depth: null, colors: true });
     }
 
@@ -263,11 +270,11 @@ ${JSON.stringify(diffBlocks, null, 2)}
       const parsed = JSON.parse(raw);
       return parsed;
     } catch (err) {
-      console.error(chalk.red("❌ Error parsing block JSON:"), raw);
+      console.error(chalk.red(`${t("errorParsingJSON", lang)}`), raw);
       return null;
     }
   } catch (error) {
-    console.error(chalk.red("❌ Error in analyzeDiffBlock:"), error.message);
+    console.error(chalk.red(`${t("errorAnalyzeDiffBlock", lang)}`), error.message);
     return "⚠️ Error analyzing diff.";
   }
 }
@@ -326,7 +333,7 @@ RESPONSE FORMAT (mandatory):
   ];
 
   if (verbose) {
-    console.log(chalk.gray("\n📤 Prompt enviado al modelo:\n"));
+    console.log(chalk.gray(t("promptSent", lang)));
     console.dir(messages, { depth: null, colors: true });
   }
 
@@ -349,7 +356,7 @@ RESPONSE FORMAT (mandatory):
     const raw = response.data.choices[0]?.message?.content;
     return JSON.parse(raw);
   } catch (err) {
-    console.error(chalk.red("❌ Error al resumir grupo:"), err.message);
+    console.error(chalk.red(`${t("errorSummarizeGroup", lang)}`), err.message);
     return {
       title:
         lang === "en"

--- a/src/changelogHandler.js
+++ b/src/changelogHandler.js
@@ -2,8 +2,9 @@ import fs from "fs/promises";
 import { existsSync } from "fs";
 import { execSync } from "child_process";
 import chalk from "chalk";
+import { t } from "./i18n.js";
 
-export async function appendToChangelog(blocks) {
+export async function appendToChangelog(blocks, lang = "en") {
   const changelogPath = "CHANGELOG.md";
   const branch = execSync("git rev-parse --abbrev-ref HEAD").toString().trim();
   const commit = execSync("git rev-parse HEAD").toString().trim().slice(0, 7);
@@ -26,5 +27,5 @@ export async function appendToChangelog(blocks) {
     await fs.appendFile(changelogPath, changelogEntry);
   }
 
-  console.log(chalk.green("📝 CHANGELOG.md actualizado con los cambios."));
+  console.log(chalk.green(t("changelogUpdated", lang)));
 }

--- a/src/commitFlow.js
+++ b/src/commitFlow.js
@@ -1,34 +1,35 @@
 import inquirer from "inquirer";
+import { t } from "./i18n.js";
 
-export async function promptCommitAction(summaries) {
+export async function promptCommitAction(summaries, lang = "en") {
   const opciones =
     summaries.length === 1
       ? [
-          { name: "✅ Hacer commit", value: "single" },
-          { name: "📋 Copiar mensaje al portapapeles", value: "copy" },
-          { name: "❌ Cancelar", value: "cancel" },
+          { name: t("optionCommit", lang), value: "single" },
+          { name: t("optionCopy", lang), value: "copy" },
+          { name: t("optionCancel", lang), value: "cancel" },
         ]
       : [
           {
-            name: "🔀 Hacer múltiples commits (uno por bloque funcional)",
+            name: t("optionMultiple", lang),
             value: "multi",
           },
           {
-            name: "🧷 Unificar todos los mensajes y hacer un solo commit",
+            name: t("optionUnified", lang),
             value: "unified",
           },
           {
-            name: "📋 Copiar todos los mensajes al portapapeles",
+            name: t("optionCopyAll", lang),
             value: "copy",
           },
-          { name: "❌ Cancelar", value: "cancel" },
+          { name: t("optionCancel", lang), value: "cancel" },
         ];
 
   const { accion } = await inquirer.prompt([
     {
       type: "list",
       name: "accion",
-      message: "¿Qué querés hacer con los commits sugeridos?",
+      message: t("commitPromptQuestion", lang),
       choices: opciones,
     },
   ]);
@@ -47,11 +48,11 @@ import {
 import { appendToChangelog } from "./changelogHandler.js";
 import chalk from "chalk";
 
-export async function performCommitActions(accion, summaries, blocks) {
+export async function performCommitActions(accion, summaries, blocks, lang = "en") {
   let huboCambiosEnChangelog = false;
 
   if (accion === "cancel") {
-    console.log(chalk.yellow("❌ Operación cancelada por el usuario."));
+    console.log(chalk.yellow(t("operationCancelled", lang)));
     return;
   }
 
@@ -60,7 +61,7 @@ export async function performCommitActions(accion, summaries, blocks) {
       .map((s) => `${s.resumen.title}\n\n${s.resumen.content}`)
       .join("\n\n");
     await clipboardy.write(texto);
-    console.log(chalk.green("📋 Mensajes copiados al portapapeles."));
+    console.log(chalk.green(t("messagesCopied", lang)));
     return;
   }
 
@@ -68,17 +69,17 @@ export async function performCommitActions(accion, summaries, blocks) {
     const { title, content } = summaries[0].resumen;
     const fullPaths = obtenerArchivosDesdeDiff([summaries[0]], blocks);
 
-    await stageSpecificFiles(fullPaths);
-    await commitWithMessage(`${title}\n\n${content}`);
-    console.log(chalk.green("✅ Commit realizado con éxito."));
+    await stageSpecificFiles(fullPaths, lang);
+    await commitWithMessage(`${title}\n\n${content}`, lang);
+    console.log(chalk.green(t("commitSuccess", lang)));
 
     try {
-      await appendToChangelog(summaries[0].grupo);
-      console.log(chalk.gray("📘 Entrada de CHANGELOG agregada."));
+      await appendToChangelog(summaries[0].grupo, lang);
+      console.log(chalk.gray(t("changelogEntryAdded", lang)));
       huboCambiosEnChangelog = true;
     } catch (error) {
       console.warn(
-        chalk.yellow("⚠️  No se pudo actualizar el CHANGELOG:"),
+        chalk.yellow(`${t("changelogUpdateFail", lang)}`),
         error.message
       );
     }
@@ -87,23 +88,23 @@ export async function performCommitActions(accion, summaries, blocks) {
   if (accion === "unified") {
     const fullPaths = obtenerArchivosDesdeDiff(summaries, blocks);
 
-    await stageSpecificFiles(fullPaths);
+    await stageSpecificFiles(fullPaths, lang);
 
     const all = summaries
       .map((s) => `${s.resumen.title}\n\n${s.resumen.content}`)
       .join("\n\n");
 
-    await commitWithMessage(all);
-    console.log(chalk.green("✅ Commit unificado realizado con éxito."));
+    await commitWithMessage(all, lang);
+    console.log(chalk.green(t("unifiedCommitSuccess", lang)));
 
     try {
       const allGrupos = summaries.flatMap((s) => s.grupo);
-      await appendToChangelog(allGrupos);
-      console.log(chalk.gray("📘 Entrada de CHANGELOG agregada."));
+      await appendToChangelog(allGrupos, lang);
+      console.log(chalk.gray(t("changelogEntryAdded", lang)));
       huboCambiosEnChangelog = true;
     } catch (error) {
       console.warn(
-        chalk.yellow("⚠️  No se pudo actualizar el CHANGELOG:"),
+        chalk.yellow(`${t("changelogUpdateFail", lang)}`),
         error.message
       );
     }
@@ -118,19 +119,21 @@ export async function performCommitActions(accion, summaries, blocks) {
       // Usar helper para obtener los archivos relacionados
       const fullPaths = obtenerArchivosDesdeDiff([summaries[i]], blocks);
 
-      await stageSpecificFiles(fullPaths);
-      await commitWithMessage(`${resumen.title}\n\n${resumen.content}`);
-      console.log(chalk.green(`✅ Commit realizado para: ${resumen.title}`));
+      await stageSpecificFiles(fullPaths, lang);
+      await commitWithMessage(`${resumen.title}\n\n${resumen.content}`, lang);
+      console.log(
+        chalk.green(`${t("commitMadeFor", lang)} ${resumen.title}`)
+      );
 
       try {
         if (grupo?.length) {
-          await appendToChangelog(grupo);
-          console.log(chalk.gray("📘 Entrada de CHANGELOG agregada."));
+          await appendToChangelog(grupo, lang);
+          console.log(chalk.gray(t("changelogEntryAdded", lang)));
           huboCambiosEnChangelog = true;
         }
       } catch (error) {
         console.warn(
-          chalk.yellow("⚠️  No se pudo actualizar el CHANGELOG:"),
+          chalk.yellow(`${t("changelogUpdateFail", lang)}`),
           error.message
         );
       }
@@ -139,28 +142,26 @@ export async function performCommitActions(accion, summaries, blocks) {
 
   // 🔚 Commit final de CHANGELOG (si hubo cambios)
   if (huboCambiosEnChangelog) {
-    await commitChangelogIfChanged();
+    await commitChangelogIfChanged(lang);
   }
   return;
 }
 
-export async function commitChangelogIfChanged() {
+export async function commitChangelogIfChanged(lang = "en") {
   try {
-    await stageSpecificFiles(["CHANGELOG.md"]);
+    await stageSpecificFiles(["CHANGELOG.md"], lang);
     const status = await getGitStatus();
     const changelogModificado = status.staged.includes("CHANGELOG.md");
 
     if (changelogModificado) {
-      await commitWithMessage("chore(changelog): actualizar CHANGELOG.md");
-      console.log(chalk.green("📝 Commit del CHANGELOG realizado."));
+      await commitWithMessage("chore(changelog): actualizar CHANGELOG.md", lang);
+      console.log(chalk.green(t("changelogCommit", lang)));
     } else {
-      console.log(
-        chalk.gray("📘 No hubo cambios en CHANGELOG.md. No se hizo commit.")
-      );
+      console.log(chalk.gray(t("noChangelogChanges", lang)));
     }
   } catch (error) {
     console.warn(
-      chalk.yellow("⚠️  No se pudo realizar el commit del CHANGELOG:"),
+      chalk.yellow(`${t("changelogCommitFail", lang)}`),
       error.message
     );
   }

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@ import os from "os";
 import path from "path";
 import fs from "fs-extra";
 import inquirer from "inquirer";
+import { t } from "./i18n.js";
 
 // Ruta centralizada del archivo de configuración
 const configPath = path.join(
@@ -28,13 +29,14 @@ export async function getAPIKey() {
   const config = await loadConfig();
   if (config.apiKey) return config.apiKey;
 
+  const langPrompt = getLangFromArgs() || "es";
+
   const { apiKey } = await inquirer.prompt([
     {
       type: "input",
       name: "apiKey",
-      message: "🔑 Ingresá tu OpenRouter API Key:",
-      validate: (input) =>
-        input.trim() !== "" || "La API Key no puede estar vacía.",
+      message: t("apiKeyPrompt", langPrompt),
+      validate: (input) => input.trim() !== "" || t("apiKeyEmpty", langPrompt),
     },
   ]);
 
@@ -59,7 +61,7 @@ export async function getLanguage() {
     {
       type: "list",
       name: "selectedLang",
-      message: "Seleccioná el idioma para la interfaz:",
+      message: t("selectLanguage", "es"),
       choices: [
         { name: "Español", value: "es" },
         { name: "English", value: "en" },

--- a/src/contextBuilder.js
+++ b/src/contextBuilder.js
@@ -1,10 +1,11 @@
 import fs from "fs";
 import path from "path";
 import { splitDiffByFile, splitDiffIntoChunks } from "./codeHandler.js";
+import { t } from "./i18n.js";
 
 import { extractContextMapFromCode } from "./contextExtractor.js"; // nuevo AST completo
 
-export async function buildContextForDiff(diffText) {
+export async function buildContextForDiff(diffText, lang = "en") {
   const blocks = splitDiffByFile(diffText);
   const enriched = [];
 
@@ -15,12 +16,12 @@ export async function buildContextForDiff(diffText) {
     try {
       sourceCode = fs.readFileSync(fullPath, "utf-8");
     } catch {
-      console.warn(`⚠️ No se pudo leer el archivo: ${fullPath}`);
+      console.warn(`${t("fileReadWarning", lang)} ${fullPath}`);
       continue;
     }
 
     // 🧠 Extraer el árbol jerárquico de contextos
-    const contextMap = extractContextMapFromCode(sourceCode, filePath);
+    const contextMap = extractContextMapFromCode(sourceCode, filePath, lang);
     const scopedChanges = [];
     let changeIdCounter = 1;
 

--- a/src/contextExtractor.js
+++ b/src/contextExtractor.js
@@ -1,6 +1,7 @@
 // contextExtractor.js
 import { parse } from "@babel/parser";
 import babelTraverse from "@babel/traverse";
+import { t } from "./i18n.js";
 const traverse = babelTraverse.default || babelTraverse;
 
 /**
@@ -9,7 +10,7 @@ const traverse = babelTraverse.default || babelTraverse;
  * @param {string} sourceCode
  * @returns {Object} contextMap - { [id]: { id, type, code, loc, parentId, children, changes } }
  */
-export function extractContextMapFromCode(sourceCode, filename) {
+export function extractContextMapFromCode(sourceCode, filename, lang = "en") {
   try {
     const ast = parse(sourceCode, {
       sourceType: "module",
@@ -99,7 +100,7 @@ export function extractContextMapFromCode(sourceCode, filename) {
 
     return Object.fromEntries(contextMap);
   } catch (err) {
-    console.error(`❌ Error parseando ${filename || "archivo"}:`, err.message);
+    console.error(`${t("errorParsing", lang)} ${filename || "archivo"}:`, err.message);
     return {};
   }
 }

--- a/src/devToolsHelper.js
+++ b/src/devToolsHelper.js
@@ -1,15 +1,18 @@
 import readline from "readline";
+import { t } from "./i18n.js";
 
 export async function waitForUserInput(
-  message = "Presioná ENTER para continuar..."
+  message,
+  lang = "en"
 ) {
+  const finalMsg = message || t("pressEnter", lang);
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
 
   return new Promise((resolve) =>
-    rl.question(`${message}\n`, () => {
+    rl.question(`${finalMsg}\n`, () => {
       rl.close();
       resolve();
     })

--- a/src/diffValidator.js
+++ b/src/diffValidator.js
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import { getGitDiff } from "./gitHandler.js";
 import { splitDiffByFile } from "./codeHandler.js";
+import { t } from "./i18n.js";
 
 export function Dashboard() {
   return 32;
@@ -10,17 +11,17 @@ export function increment() {
   return 32;
 }
 
-export async function getAndValidateDiff(isVerbose) {
+export async function getAndValidateDiff(isVerbose, lang = "en") {
   const diff = await getGitDiff();
 
   if (!diff.trim()) {
-    console.log(chalk.yellow("⚠️  No staged changes found."));
-    console.log(chalk.gray("Use `git add <file>` to stage changes."));
+    console.log(chalk.yellow(t("noStagedChanges", lang)));
+    console.log(chalk.gray(t("useGitAdd", lang)));
     return null;
   }
 
   if (isVerbose) {
-    console.log(chalk.gray("\n🔍 Full diff:\n"));
+    console.log(chalk.gray(t("fullDiff", lang)));
     console.log(diff);
   }
 
@@ -32,9 +33,9 @@ export async function getAndValidateDiff(isVerbose) {
 
   if (isVerbose) {
     console.log(
-      chalk.green(`✅ ${movedSummaries.length} function(s) moved:\n`)
+      chalk.green(`✅ ${movedSummaries.length} ${t("functionsMoved", lang)}`)
     );
-    console.log(chalk.green(`✅ Refactor summary:\n`));
+    console.log(chalk.green(`✅ ${t("refactorSummary", lang)}`));
     console.dir(movedSummaries, { depth: null, colors: true });
   }
 
@@ -65,7 +66,7 @@ This block represents either a refactor or removal decision.
   });
 
   if (isVerbose) {
-    console.log(chalk.blue("\n🧱 Artificial blocks:"));
+    console.log(chalk.blue(t("artificialBlocks", lang)));
     console.table(
       artificialBlocks.map((b) => ({
         file: b.filePath,
@@ -86,9 +87,10 @@ This block represents either a refactor or removal decision.
   if (isVerbose) {
     console.log(
       chalk.gray(
-        `\n🧹 Removed ${
+        t("removedBlocksInfo", lang).replace(
+          "{count}",
           blocks.length - filteredOriginalBlocks.length
-        } original deleted block(s) in favor of artificial versions.`
+        )
       )
     );
   }

--- a/src/gitHandler.js
+++ b/src/gitHandler.js
@@ -1,6 +1,7 @@
 import simpleGit from "simple-git";
 const git = simpleGit();
 import fs from "fs-extra";
+import { t } from "./i18n.js";
 
 export async function getGitDiff() {
   try {
@@ -26,7 +27,7 @@ export async function unstageAllChanges() {
   }
 }
 
-export async function stageSpecificFiles(files) {
+export async function stageSpecificFiles(files, lang = "en") {
   const toAdd = [];
   const toRemove = [];
 
@@ -41,24 +42,24 @@ export async function stageSpecificFiles(files) {
 
   try {
     if (toAdd.length > 0) {
-      console.log("Agregando archivos:", toAdd);
+      console.log(`${t("addingFiles", lang)}`, toAdd);
       await git.add(toAdd);
     }
     if (toRemove.length > 0) {
-      console.log("Eliminando archivos:", toRemove);
+      console.log(`${t("removingFiles", lang)}`, toRemove);
       await git.rm(toRemove);
     }
   } catch (err) {
-    console.error("Error al hacer staging:", err);
+    console.error(`${t("stagingError", lang)}`, err);
     throw new Error(`No se pudo hacer staging de archivos: ${err.message}`);
   }
 }
 
-export async function commitWithMessage(message) {
+export async function commitWithMessage(message, lang = "en") {
   try {
     await git.commit(message);
   } catch (err) {
-    console.error("Error al hacer git add:", err);
+    console.error(`${t("gitAddError", lang)}`, err);
 
     throw new Error(
       `No se pudo hacer git add para archivos específicos: ${err.message}`

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -12,4 +12,69 @@ export default {
   helpLang: "--lang [es|en]     Change interface language",
   helpVerbose: "--verbose         Show detailed logs",
   helpHelp: "--help             Display this help message",
+  addingFiles: "Adding files:",
+  removingFiles: "Removing files:",
+  stagingError: "Error staging files:",
+  gitAddError: "Error running git add:",
+  errorParsing: "❌ Error parsing",
+  fileReadWarning: "⚠️ Could not read file:",
+  analyzingDeleted: "🗑️ Analyzing deleted/refactored files...",
+  deletedSummarySuccess: "🧾 Deleted/refactored files summarized",
+  verboseDeletedSummary: "📚 Summary for deleted/refactored files:\n",
+  errorProcessingDeleted: "❌ Error processing deleted/refactored files",
+  analyzingFile: "🤖 Analyzing {file} with AI...",
+  fileProcessed: "📄 {file} processed successfully",
+  verboseAnalyzeResponse: "📚 analyzeDiffBlock response:\n",
+  errorProcessingFile: "❌ Error processing {file}",
+  gitAdviceTitle: "📚 Git advice:",
+  gitAdviceText:
+    "It is recommended to make one commit per change with a single responsibility.\n" +
+    "This improves traceability, teamwork and tools like git bisect.\n",
+  aiAdviceTitle: "🤝 One more tip from your AI buddy:",
+  aiAdviceText:
+    "One of the goals of {tool} is to help you improve the quality of your commits. 💎📈\n" +
+    "Well crafted commits not only tell a better story of the code, but also\n" +
+    "make debugging, PRs and team collaboration easier.\n\n" +
+    "If you agree, next time you finish an independent feature or change,\n" +
+    "try running {tool} right after that step. 🧠⚡\n\n" +
+    "Although today {tool} can suggest multiple commits separated by file or general purpose,\n" +
+    "it still can't accurately detect if there's more than one feature inside the same file or block.\n" +
+    "That would require a deeper functional context analysis, something we're still exploring. 🤖🔬\n\n" +
+    "So whenever you finish something self-contained, use {tool} and we'll solve it in seconds. 🚀\n" +
+    "You code, I commit! 😉",
+  chooseModel: "\n\n\n🧠 Which LLM model do you want to use?",
+  promptSent: "\n📤 Prompt sent to model:\n",
+  errorParsingJSON: "❌ Error parsing block JSON:",
+  errorAnalyzeDiffBlock: "❌ Error in analyzeDiffBlock:",
+  errorSummarizeGroup: "❌ Error summarizing group:",
+  commitPromptQuestion: "What do you want to do with the suggested commits?",
+  optionCommit: "✅ Make commit",
+  optionCopy: "📋 Copy message to clipboard",
+  optionCancel: "❌ Cancel",
+  optionMultiple: "🔀 Make multiple commits (one per functional block)",
+  optionUnified: "🧷 Combine all messages and make a single commit",
+  optionCopyAll: "📋 Copy all messages to clipboard",
+  operationCancelled: "❌ Operation cancelled by user.",
+  messagesCopied: "📋 Messages copied to clipboard.",
+  commitSuccess: "✅ Commit completed successfully.",
+  changelogEntryAdded: "📘 CHANGELOG entry added.",
+  changelogUpdateFail: "⚠️  Could not update CHANGELOG:",
+  unifiedCommitSuccess: "✅ Unified commit completed successfully.",
+  commitMadeFor: "✅ Commit made for:",
+  changelogCommit: "📝 CHANGELOG commit created.",
+  noChangelogChanges: "📘 No changes in CHANGELOG.md. No commit made.",
+  changelogCommitFail: "⚠️  Could not commit CHANGELOG:",
+  noStagedChanges: "⚠️  No staged changes found.",
+  useGitAdd: "Use `git add <file>` to stage changes.",
+  fullDiff: "\n🔍 Full diff:\n",
+  functionsMoved: "function(s) moved:\n",
+  refactorSummary: "Refactor summary:\n",
+  artificialBlocks: "\n🧱 Artificial blocks:",
+  removedBlocksInfo:
+    "Removed {count} original deleted block(s) in favor of artificial versions.",
+  changelogUpdated: "📝 CHANGELOG.md updated with changes.",
+  apiKeyPrompt: "🔑 Enter your OpenRouter API Key:",
+  apiKeyEmpty: "API Key cannot be empty.",
+  selectLanguage: "Select interface language:",
+  pressEnter: "Press ENTER to continue...",
 };

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -12,4 +12,69 @@ export default {
   helpLang: "--lang [es|en]     Cambia el idioma de la interfaz",
   helpVerbose: "--verbose         Muestra logs detallados",
   helpHelp: "--help             Muestra este mensaje de ayuda",
-};
+  addingFiles: "Agregando archivos:",
+  removingFiles: "Eliminando archivos:",
+  stagingError: "Error al hacer staging:",
+  gitAddError: "Error al hacer git add:",
+  errorParsing: "❌ Error parseando",
+  fileReadWarning: "⚠️ No se pudo leer el archivo:",
+  analyzingDeleted: "🗑️ Analizando archivos eliminados/refactorizados...",
+  deletedSummarySuccess: "🧾 Archivos eliminados/refactorizados resumidos",
+  verboseDeletedSummary: "📚 Resumen de archivos eliminados/refactorizados:\n",
+  errorProcessingDeleted: "❌ Error procesando archivos eliminados/refactorizados",
+  analyzingFile: "🤖 Analizando {file} con IA...",
+  fileProcessed: "📄 {file} procesado correctamente",
+  verboseAnalyzeResponse: "📚 Respuesta de analyzeDiffBlock:\n",
+  errorProcessingFile: "❌ Error al procesar {file}",
+  gitAdviceTitle: "📚 Consejo Git:",
+  gitAdviceText:
+    "Se recomienda realizar un commit por cada cambio con responsabilidad única.\n" +
+    "Esto mejora la trazabilidad, facilita el trabajo en equipo y el uso de herramientas como git bisect.\n",
+  aiAdviceTitle: "🤝 Un consejo más de tu compa AI:",
+  aiAdviceText:
+    "Uno de los objetivos de {tool} es justamente ayudarte a mejorar la calidad de tus commits. 💎📈\n" +
+    "Commits bien pensados no solo cuentan una mejor historia del código, sino que también\n" +
+    "facilitan el debugging, los PRs y la colaboración con el equipo.\n\n" +
+    "Si te parece bien, la próxima vez que termines una funcionalidad o cambio independiente,\n" +
+    "probá correr directamente {tool} apenas termines ese paso. 🧠⚡\n\n" +
+    "Aunque hoy {tool} puede sugerir múltiples commits separados por archivo o propósito general,\n" +
+    "aún no puede detectar con precisión si hay más de una funcionalidad dentro del mismo archivo o bloque de código.\n" +
+    "Eso requeriría un análisis más profundo del contexto funcional, algo que todavía estamos explorando. 🤖🔬\n\n" +
+    "Por eso, cada vez que termines algo autocontenible, usá {tool} y lo resolvemos en segundos. 🚀\n" +
+    "¡Vos programás, yo comiteo! 😉",
+  chooseModel: "\n\n\n🧠 ¿Qué modelo LLM querés usar?",
+  promptSent: "\n📤 Prompt enviada al modelo:\n",
+  errorParsingJSON: "❌ Error parsing block JSON:",
+  errorAnalyzeDiffBlock: "❌ Error in analyzeDiffBlock:",
+  errorSummarizeGroup: "❌ Error al resumir grupo:",
+  commitPromptQuestion: "¿Qué querés hacer con los commits sugeridos?",
+  optionCommit: "✅ Hacer commit",
+  optionCopy: "📋 Copiar mensaje al portapapeles",
+  optionCancel: "❌ Cancelar",
+  optionMultiple: "🔀 Hacer múltiples commits (uno por bloque funcional)",
+  optionUnified: "🧷 Unificar todos los mensajes y hacer un solo commit",
+  optionCopyAll: "📋 Copiar todos los mensajes al portapapeles",
+  operationCancelled: "❌ Operación cancelada por el usuario.",
+  messagesCopied: "📋 Mensajes copiados al portapapeles.",
+  commitSuccess: "✅ Commit realizado con éxito.",
+  changelogEntryAdded: "📘 Entrada de CHANGELOG agregada.",
+  changelogUpdateFail: "⚠️  No se pudo actualizar el CHANGELOG:",
+  unifiedCommitSuccess: "✅ Commit unificado realizado con éxito.",
+  commitMadeFor: "✅ Commit realizado para:",
+  changelogCommit: "📝 Commit del CHANGELOG realizado.",
+  noChangelogChanges: "📘 No hubo cambios en CHANGELOG.md. No se hizo commit.",
+  changelogCommitFail: "⚠️  No se pudo realizar el commit del CHANGELOG:",
+  noStagedChanges: "⚠️  No se encontraron cambios en staging.",
+  useGitAdd: "Usa `git add <file>` para agregar cambios.",
+  fullDiff: "\n🔍 Diff completo:\n",
+  functionsMoved: "función(es) movida(s):\n",
+  refactorSummary: "Resumen de refactor:\n",
+  artificialBlocks: "\n🧱 Bloques artificiales:",
+  removedBlocksInfo:
+    "Se eliminaron {count} bloque(s) eliminado(s) original(es) en favor de versiones artificiales.",
+  changelogUpdated: "📝 CHANGELOG.md actualizado con los cambios.",
+  apiKeyPrompt: "🔑 Ingresá tu OpenRouter API Key:",
+  apiKeyEmpty: "La API Key no puede estar vacía.",
+  selectLanguage: "Seleccioná el idioma para la interfaz:",
+  pressEnter: "Presioná ENTER para continuar...",
+}; 


### PR DESCRIPTION
## Summary
- localize the remaining CLI messages
- pass `lang` through the workflow so all modules can translate
- add English and Spanish strings for new log messages

## Testing
- `npm test` *(fails: Error: no test specified)*